### PR TITLE
feat: Adding build to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 name: nullinside-ui
 services:
     nullinside-ui:
+        build:
+            context: .
+            args:
+                - BUILD_ENVIRONMENT=prod
+            tags:
+                - "nullinside-ui:latest"
         logging:
             driver: loki
             options:

--- a/go.sh
+++ b/go.sh
@@ -1,6 +1,6 @@
 export IP_ADDRESS=$(/sbin/ip -o -4 addr list eno2 | awk '{print $4}' | cut -d/ -f1)
 
 cp /secrets/certs/* nginx/filesystem/etc/nginx/certs
-docker build -t nullinside-ui:latest --build-arg BUILD_ENVIRONMENT=prod --build-arg IP_ADDRESS=$IP_ADDRESS .
+docker compose build --build-arg IP_ADDRESS=$IP_ADDRESS .
 docker compose down
 docker compose up -d


### PR DESCRIPTION
No need to use part regular builds and part docker compose, just in for a penny in for a pound.

nullinside-development-group/nullinside-api#60