### PR TITLE
Fix/karma

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,32 +19,29 @@ on:
     - cron: '22 20 * * 6'
 
 jobs:
-  # Temporarily removing this, for some reason the "singleRun" option of Karma is being ignored by Karma and it is never closing
-  # this is a new issue since updating to Angular v20
-  # 
-  # tests:
-  #   name: ng test_automation
-  #   runs-on: [ self-hosted ]
-  #   steps:
-  #     # Required for our repo to run
-  #     - name: Install NodeJS
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 'lts/iron'
-  #     - name: Install Chrome
-  #       uses: browser-actions/setup-chrome@v1
-  # 
-  #     # Checkout the code
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  # 
-  #     # Run the ng lint command
-  #     - name: Install NPM Packages
-  #       working-directory: ./src
-  #       run: npm install
-  #     - name: ng test_automation
-  #       working-directory: ./src
-  #       run: npm run test_automation
+  tests:
+    name: ng test
+    runs-on: [ self-hosted ]
+    steps:
+      # Required for our repo to run
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/iron'
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      # Checkout the code
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Run the ng lint command
+      - name: Install NPM Packages
+        working-directory: ./src
+        run: npm install
+      - name: ng test
+        working-directory: ./src
+        run: npm run test_automation
 
   lint:
     name: ng lint

--- a/src/angular.json
+++ b/src/angular.json
@@ -84,7 +84,7 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -101,7 +101,7 @@
               "src/styles.scss"
             ],
             "scripts": [],
-            "karmaConfig": "karma.conf.js"
+            "karmaConfig": "karma.conf.prod.js"
           }
         },
         "lint": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2000.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2000.1.tgz",
-      "integrity": "sha512-EcOGU1xEhARYpDF391VaeUg/+YRym9OxzJMcc0rSHl3YLK8/m+24ap2YAQY5N7n9+mmEqHVu/q31ldFpOoMCTw==",
+      "version": "0.2000.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2000.2.tgz",
+      "integrity": "sha512-adJYWJWuyXFtCOg2lZTV/7CImf4ifxd6c//VXuq5kx7AiSGTIH5Nf2xTQe8ZAZqytUmDgnoNMDhGRQ9b3C5TnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.0.1",
+        "@angular-devkit/core": "20.0.2",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.0.1.tgz",
-      "integrity": "sha512-rUrGwdqUNOy6AlisBjOaQncZOanwqgHIa6HDw9a0nrbQxDpLzwJAiNLGcmIivfvAXxSq60+YFHHM48VV42oxyg==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.0.2.tgz",
+      "integrity": "sha512-IvIyWSat0W9ZlTn6Hd6xCoMal49JJmrml3oV2+dYFadt0wFcxZ5ygIF9pRymLWBHEjCUhuZzBCAD3gKgZXPMHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2000.1",
-        "@angular-devkit/build-webpack": "0.2000.1",
-        "@angular-devkit/core": "20.0.1",
-        "@angular/build": "20.0.1",
+        "@angular-devkit/architect": "0.2000.2",
+        "@angular-devkit/build-webpack": "0.2000.2",
+        "@angular-devkit/core": "20.0.2",
+        "@angular/build": "20.0.2",
         "@babel/core": "7.27.1",
         "@babel/generator": "7.27.1",
         "@babel/helper-annotate-as-pure": "7.27.1",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.27.2",
         "@babel/runtime": "7.27.1",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "20.0.1",
+        "@ngtools/webpack": "20.0.2",
         "@vitejs/plugin-basic-ssl": "2.0.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.21",
@@ -158,7 +158,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.0.1",
+        "@angular/ssr": "^20.0.2",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -215,13 +215,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2000.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2000.1.tgz",
-      "integrity": "sha512-v+A08zOUC3wrP9msN2+qrAaKnDEKi9H1o5bYOe/yH9S8ZXZ56R/r5EsY58Vcf6yQSywRDip2HJnPDtIGkQYnew==",
+      "version": "0.2000.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2000.2.tgz",
+      "integrity": "sha512-kFqvZNOcU1zwwMRG3Kh7V661HWgtt9G3+xId9A2VNXvW0ZfuVZmgfaR8TLEmtCSrQ4KHGGQmK0zn2lPHttY5HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2000.1",
+        "@angular-devkit/architect": "0.2000.2",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.0.1.tgz",
-      "integrity": "sha512-Ilafyj8JVwq3NZsaiGw5UDkP4EAkGKiEvZ4TC3WVidZbM4EpKt9/Jd7ZpsTRGDLG429U+fGhay+ZQeCFGqy5rA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.0.2.tgz",
+      "integrity": "sha512-qqTSpcIw+TqJ6u/tkQzqgpwVelHsHr8Jhws1Vlx6E0L6E+cRILBK48i9ttE+oYkQlcopQ3VZAmzcZodXJ1SQ9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -263,13 +263,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.0.1.tgz",
-      "integrity": "sha512-bSr/5YIdjtwKYqylkYrlOVP+tuFz+tfOldmLfWHAsDGnJUznb5t4ckx6yyROp+iDQfu2Aez09p+l4KfUBq+H9A==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.0.2.tgz",
+      "integrity": "sha512-r1aSZhcadLtUMhzUUfy+pkJdZW93z8WQtpGR24y88yFpPgDL5kY85VSlOzjGgo1vEs8Dd7ADcOcsVsUW8MxQ3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.0.1",
+        "@angular-devkit/core": "20.0.2",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "8.2.0",
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.0.2.tgz",
-      "integrity": "sha512-p9TqZdVOFWMF75lfxk++5GZOBGO3K7qVdAXiQw89VLac8yqsu9iXFlcq34x256McHxONTjrrKBeP5oU1T8rxCw==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.0.3.tgz",
+      "integrity": "sha512-R6yv2RmrH49nW1ybgoOMw5pWzqaRYo8Kn3VtvrUDBty4TXjwc0addaw/t89n0smO3/lmBB4vnlRScePAEQZ/3w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -397,19 +397,19 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.0.2",
-        "@angular/core": "20.0.2"
+        "@angular/common": "20.0.3",
+        "@angular/core": "20.0.3"
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.0.1.tgz",
-      "integrity": "sha512-m/0jtXIeOaoU/WXtMLRuvq7UaGRxNHpoRKVVoJrifvZuNBYGM4e2lzxlIlo8kiQhPpZQc0zcAMoosbmzKKdkUQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.0.2.tgz",
+      "integrity": "sha512-nxha/dncAwEbY0nkgDWeiWSi+MSCJBuQbFf5bjTZ+pu0fS+5SOQllZKzZE9H+dms/JsLHm2YmPiScIYVvUenDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2000.1",
+        "@angular-devkit/architect": "0.2000.2",
         "@babel/core": "7.27.1",
         "@babel/helper-annotate-as-pure": "7.27.1",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -451,7 +451,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.0.1",
+        "@angular/ssr": "^20.0.2",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^20.0.0",
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.0.2.tgz",
-      "integrity": "sha512-gRQcpTNhnwBxXSmpnrljODUHQmB2Hnxc6L2Ad6mSMV+c3opd9KIFxL5eG2WOOPHGAaPrV4gNFw+t1i01U4grTg==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.0.3.tgz",
+      "integrity": "sha512-70KG8GpK4aV9j5hUkpDZJQ6oMgCuaCRY6JX1axPxkNtQaiK6PAmTfQLiGqF2cYhbQneeq3uGvTorAjRfvp8NPQ==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.1.2",
@@ -516,18 +516,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.0.1.tgz",
-      "integrity": "sha512-OU91byvG/WsDDUVmXIJr3/sU89U6g8G8IXrqgVRVPgjXKEQMnUNBlmygD2rMUR5C02g2lGc6s2j0hnOJ/dDNOw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.0.2.tgz",
+      "integrity": "sha512-LzBONPETA1uCZuylgZRYe+vImf8i+rRrwAgOBHWbW2wxut9ZQ8ZFwQgNkjvDhE7DLmsFV+GskfAs5+Td/5LZwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2000.1",
-        "@angular-devkit/core": "20.0.1",
-        "@angular-devkit/schematics": "20.0.1",
+        "@angular-devkit/architect": "0.2000.2",
+        "@angular-devkit/core": "20.0.2",
+        "@angular-devkit/schematics": "20.0.2",
         "@inquirer/prompts": "7.5.1",
         "@listr2/prompt-adapter-inquirer": "2.0.22",
-        "@schematics/angular": "20.0.1",
+        "@schematics/angular": "20.0.2",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.0.2.tgz",
-      "integrity": "sha512-dqzKFL2MgPpQiaY9ZyDhGZYWEXblsqofW6czH/+HkmlNgSmDCBaY/UhNQShxNQ0KQbR1o08OWuQr29zxkY1CMA==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.0.3.tgz",
+      "integrity": "sha512-HqqVqaj+xzByWJOIrONVRkpvM6mRuGmC+m9wKixhc9f+xXsymVTBR6xg+G/RwyYP2NuC5chxIZbaJTz2Hj+6+g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -560,14 +560,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.0.2",
+        "@angular/core": "20.0.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.0.2.tgz",
-      "integrity": "sha512-BJYXGUZaY9awYvgt0w9TDq73A1+m8W5eMRn/krWeQcfWakwTgs27BSxmhfJhD45KrMrky5yxAvGgqSfMKrLeng==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.0.3.tgz",
+      "integrity": "sha512-CShPNvqqV5Cleyho8CKtcFlt7l2thHPUdXZPtKHH3Zf43KojvJbJksZLBz6ZbyoQdgxNMYSfbh4h0UbSGtPOzQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.0.2.tgz",
-      "integrity": "sha512-kVKHS5ZRadTR+rRuBl3Dsccsv/jiHXdJJYlDQwQW87afd4RtAu75P3RsSd8jaUj+7P9O4Ve4vwCZVtgOh0yxbw==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.0.3.tgz",
+      "integrity": "sha512-u+fYnx1sRrwL0fd8kaAD2LqJjfe/Zj7zyOv0A3Ue7r8jzdNsPU8MWr/QyBaWlqSpPEpR+kD3xmDvRT9ra9RTBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -600,7 +600,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.0.2",
+        "@angular/compiler": "20.0.3",
         "typescript": ">=5.8 <5.9"
       },
       "peerDependenciesMeta": {
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.0.2.tgz",
-      "integrity": "sha512-z9L8WPrHTkfupHtpO6aW4KqcqigIhxcQwCaEMgXWc5WJkoiMJSfo/dk+cyiGjCfTkc5Y6DO6f6ERi0IWYWWbPA==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.0.3.tgz",
+      "integrity": "sha512-kB6w1bQgClfmkTbWJeD3vSLqX0e3uSaJD6KJ7XXT1IEaqUs4J+mKRKHQyxpJlpdUb7R+jDaHSM/vrVF15/L2rA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -760,7 +760,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.0.2",
+        "@angular/compiler": "20.0.3",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       },
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.0.2.tgz",
-      "integrity": "sha512-RrQKwzFZsEDXsvesNXS4XxndEKZHC+VexIdRr1vlxx7isfvpl4htOxceW0D+Gvku1mnaS99eB/AWS50HxW3B3Q==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.0.3.tgz",
+      "integrity": "sha512-tb4M+c+/JnmPmtTb3+Si/DWGttnCEW5rvi4u55q+EFxYGQO0GeHa53yQTl1e2ngQLT9/kgmDAsJ2mt1Ql9N6xg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -785,22 +785,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.0.2",
-        "@angular/core": "20.0.2",
-        "@angular/platform-browser": "20.0.2",
+        "@angular/common": "20.0.3",
+        "@angular/core": "20.0.3",
+        "@angular/platform-browser": "20.0.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-20.0.2.tgz",
-      "integrity": "sha512-yIXvF+LjFdHjJWyvn1SxbWB9LdNxYnqEKbKzminW4WPXlPJMOAeyhEDFeQv9W92Zv+/ibS4tI3/SD759ejb45g==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-20.0.3.tgz",
+      "integrity": "sha512-kd5Mi6gVxcjDs1nfm8GG2rId59SXWQjkiBMqrYuhy2Trpb+zG0vrLClrpoe3JdWqoX4GJagxGwl3VRDBIoP/cw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "20.0.2",
+        "@angular/cdk": "20.0.3",
         "@angular/common": "^20.0.0 || ^21.0.0",
         "@angular/core": "^20.0.0 || ^21.0.0",
         "@angular/forms": "^20.0.0 || ^21.0.0",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.0.2.tgz",
-      "integrity": "sha512-4adMQSVlwxjY9z/LEk3Q5hr4/qbM9UD9FcqbyZOt3+BL+F2GwGdKzwg6Dj4Dv0Tv8/dudNSVgHc8lIdQ4C7K1w==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.0.3.tgz",
+      "integrity": "sha512-cba0bibw9dJ8b+a2a8mwkiq5/HPiakY9P5OiJEVefN+2V/K9CND/pW+KIbW0/P6KhSSDQ29xgcGRseVtkjYLmg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -820,9 +820,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "20.0.2",
-        "@angular/common": "20.0.2",
-        "@angular/core": "20.0.2"
+        "@angular/animations": "20.0.3",
+        "@angular/common": "20.0.3",
+        "@angular/core": "20.0.3"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.0.2.tgz",
-      "integrity": "sha512-8MDGsgcxUxSldcX6HRGB5dj+xOCQ8qmx8Vog9unEBNkuPH0vqvOepqn3prdV6dM31jYfJ9JAEKeEfNZFjuWSkA==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.0.3.tgz",
+      "integrity": "sha512-EUC0q9/L7nBQOJkOi7aKz0cKXym7XIZtZJjZ+K7hCZaE92wb+Uk5YdBfBaq6hJ3aEp896GUs3FVFI6Rxklrm2A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -842,16 +842,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.0.2",
-        "@angular/compiler": "20.0.2",
-        "@angular/core": "20.0.2",
-        "@angular/platform-browser": "20.0.2"
+        "@angular/common": "20.0.3",
+        "@angular/compiler": "20.0.3",
+        "@angular/core": "20.0.3",
+        "@angular/platform-browser": "20.0.3"
       }
     },
     "node_modules/@angular/router": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.0.2.tgz",
-      "integrity": "sha512-UyuTeoXkkZw1eFFNwrTfb1JXow6HKVdLNb3n9MhqDz+3ekdiqDH8EBaKhxYZxlcpNoa6cNbECZJYtaHy1lw38g==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.0.3.tgz",
+      "integrity": "sha512-FY2kMZjLh7NUKjSaZ1K26azl67T4aVnOD8PE/w1Ih3eQmSIlHniNP1NmCGMUy6t1O/ZV6sCSKkA5AZFv18wzIQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -860,9 +860,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.0.2",
-        "@angular/core": "20.0.2",
-        "@angular/platform-browser": "20.0.2",
+        "@angular/common": "20.0.3",
+        "@angular/core": "20.0.3",
+        "@angular/platform-browser": "20.0.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2953,9 +2953,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2968,9 +2968,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3056,9 +3056,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3133,14 +3133,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4282,9 +4295,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.0.1.tgz",
-      "integrity": "sha512-uTLeN/k+CWHMbgc7XLp0Kfs9ozNoFdsgMi+no9ygegrakGgt/CzCU1JL0VbdnFQwqPc/mDYe7S/+aDWsce8TuA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.0.2.tgz",
+      "integrity": "sha512-Thpk7LR4cpM90sjGXdvrM+HnUFvHzNJn2h0U6/Ow5ez+OipQDYKoFm1bisk2K/B6zGI7sGavXUlZagoTOXucUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5140,9 +5153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.42.0.tgz",
-      "integrity": "sha512-Gfm6cV6mj3hCUY8TqWa63DB8Mx3NADoFwiJrMpoZ1uESbK8FQV3LXkhfry+8bOniq9pqY1OdsjFWNsSbfjPugw==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.43.0.tgz",
+      "integrity": "sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==",
       "cpu": [
         "x64"
       ],
@@ -5209,14 +5222,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.0.1.tgz",
-      "integrity": "sha512-29T9vUAjZnbXM+vImIQcdqG/ibdcfj5+pybo5cbiMSwVPVyerXgnD0HKC4dyZ34V2RFZa8cmyCLe/5bYoPQ+0g==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.0.2.tgz",
+      "integrity": "sha512-TyF+/hV+8flAa/Vu8xOQF241Syg9rdbZD1dARdm6edbLo8nwxmHdRsIulRektb7oD5CpTnxpvrcNJjX77nhv6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.0.1",
-        "@angular-devkit/schematics": "20.0.1",
+        "@angular-devkit/core": "20.0.2",
+        "@angular-devkit/schematics": "20.0.2",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -5482,13 +5495,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -6512,9 +6525,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6748,9 +6761,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
+      "version": "1.0.30001722",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
+      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
       "dev": true,
       "funding": [
         {
@@ -8066,9 +8079,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8457,9 +8470,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -8841,9 +8854,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9249,9 +9262,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
-      "integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9930,9 +9943,9 @@
       }
     },
     "node_modules/karma-coverage/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10036,9 +10049,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13498,9 +13511,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
+      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14279,9 +14292,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
This fixes the bug where Karma was not exiting in a single run and so it kept the "check" alive forever.

The ng update didn't update angular.json file to point to the
`@angular-devkit` package for karma. I must have googled something to fix
it in https://github.com/nullinside-development-group/nullinside-ui/commit/77df8efb5b4715d03c42ef37ac975f0da30cd421 but only managed to install the package and not actually
tell angular.json to use it. This change makes it so that we are
building with a version of karma that allows run once (and matches what
template you get using the ng new command)