### PR TITLE
feat: making desktop login less confusing

### DIFF
--- a/src/src/app/view/login-landing-desktop/login-landing-desktop.component.html
+++ b/src/src/app/view/login-landing-desktop/login-landing-desktop.component.html
@@ -1,23 +1,26 @@
 <div class="centered-box">
-    <div class="centered-box_logo-container">
-        <app-logo/>
-    </div>
-    <div class="centered-box_content-container">
-        @if (loading) {
-            <app-loading-icon fontSize="24px" height="35px" width="35px">Logging in</app-loading-icon>
+  <div class="centered-box_logo-container">
+    <app-logo/>
+  </div>
+  <div class="centered-box_content-container">
+    @if (loggedIn) {
+      <h2>LOGGED IN SUCCESSFULLY!</h2>
+      <p>Please return to the desktop application...</p>
+    } @else if (loading) {
+      <app-loading-icon fontSize="24px" height="35px" width="35px">Logging in</app-loading-icon>
+    } @else {
+      @if (error !== '') {
+        <div class="error-banner">{{ error }}</div>
+      } @else {
+        @if (null !== oAuth) {
+          <h2>DO NOT SHOW ON STREAM</h2>
+          <button mat-stroked-button color="primary" [cdkCopyToClipboard]="JSON.stringify(oAuth)">Copy to
+            Clipboard
+          </button>
         } @else {
-            @if (error !== '') {
-                <div class="error-banner">{{ error }}</div>
-            } @else {
-                @if (null !== oAuth) {
-                    <h2>DO NOT SHOW ON STREAM</h2>
-                    <button mat-stroked-button color="primary" [cdkCopyToClipboard]="JSON.stringify(oAuth)">Copy to
-                        Clipboard
-                    </button>
-                } @else {
-                    <div class="error-banner">Failed to get you authenticated, please try again</div>
-                }
-            }
+          <div class="error-banner">Failed to get you authenticated, please try again</div>
         }
-    </div>
+      }
+    }
+  </div>
 </div>

--- a/src/src/app/view/vm-manager/vm-manager.component.ts
+++ b/src/src/app/view/vm-manager/vm-manager.component.ts
@@ -36,7 +36,7 @@ export class VmManagerComponent implements OnInit, OnDestroy {
         error: _ => {
           this.error = "Failed to refresh the list, the server may be down...";
         }
-      })
+      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
This is a total hack but trying to make the desktop login process a little less confusing. When we first load the UI from twitch giving us a token, we attempt to put our token on the clipboard. Then we observe the clipboard for the token disappearing. We assume the clipboard being cleared means the application logged in successfully.

closes nullinside-development-group/twitch-streaming-tools#56