### PR TITLE
feat: cleaning up http status codes of common apis

### DIFF
--- a/src/src/app/common/components/standard-banner/standard-banner.ts
+++ b/src/src/app/common/components/standard-banner/standard-banner.ts
@@ -19,6 +19,7 @@ export class StandardBanner implements OnInit {
   protected auth = inject(Auth);
 
   ngOnInit(): void {
+    // We don't care about the result, we'll get the updated information from the signal auth.userIsLoggedIn regardless.
     this.auth.validateToken(this.auth.getToken() || '').subscribe({});
   }
 

--- a/src/src/app/middleware/auth-guard.ts
+++ b/src/src/app/middleware/auth-guard.ts
@@ -13,12 +13,12 @@ export const authGuard: CanActivateFn = (_, __) => {
 
   return inject(Auth).validateToken(token).pipe(
     tap({
-        next: success => {
-          if (!success) {
+        next: tokenIsValid => {
+          if (!tokenIsValid) {
             window.location.href = `${environment.siteUrl}`;
           }
 
-          return success;
+          return tokenIsValid;
         },
         error: _ => {
           window.location.href = `${environment.siteUrl}`;

--- a/src/src/app/service/auth.ts
+++ b/src/src/app/service/auth.ts
@@ -32,7 +32,7 @@ export class Auth {
     this.cookieService.set('nullinside-token', JSON.stringify(token), {
       expires: 365,
       path: '/',
-      domain: 'nullinside.com',
+      domain: environment.domain,
       secure: true,
       sameSite: 'Strict'
     });
@@ -44,9 +44,8 @@ export class Auth {
   }
 
   clearToken(): void {
-    console.log('Clearing token');
     this.oauth = null;
-    this.cookieService.delete('nullinside-token', '/', 'nullinside.com', true, 'Strict');
+    this.cookieService.delete('nullinside-token', '/', environment.domain, true, 'Strict');
     this.userIsLoggedIn.set(false);
   }
 

--- a/src/src/app/view/home/home.ts
+++ b/src/src/app/view/home/home.ts
@@ -22,7 +22,6 @@ export class Home implements OnInit {
 
   public roles: WritableSignal<string[] | null> = signal(null);
   public error: WritableSignal<string | null> = signal(null);
-  public userIsLoggedIn: WritableSignal<boolean> = signal(false);
   public loading: WritableSignal<boolean> = signal(true);
 
   public apps: WritableSignal<WebsiteApp[]> = signal([
@@ -41,7 +40,11 @@ export class Home implements OnInit {
   ]);
 
   ngOnInit(): void {
-    this.userIsLoggedIn.set(null !== this.auth.getToken());
+    // No need to check roles if the user isn't logged in
+    if (!this.auth.userIsLoggedIn()) {
+      this.loading.set(false);
+      return;
+    }
 
     forkJoin({
       // We don't care if the roles don't exist. This is only for authed users. So catch the error if there is one.
@@ -64,12 +67,12 @@ export class Home implements OnInit {
           if (!twitchBotFeatureToggle || !twitchBotFeatureToggle.isEnabled) {
             this.apps.set([...this.apps().filter(f => 'Twitch Bot' !== f.displayName)])
           }
-
-          this.loading.set(false);
         },
-        error: _ => {
-          console.log(_);
+        error: err => {
+          console.log(err);
           this.error.set('Failed to get list of apps from the server, please refresh to try again...');
+        },
+        complete: () => {
           this.loading.set(false);
         }
       });

--- a/src/src/app/view/login-landing/login-landing.ts
+++ b/src/src/app/view/login-landing/login-landing.ts
@@ -56,7 +56,12 @@ export class LoginLanding implements OnInit, OnDestroy {
 
         const oauth = JSON.parse(atob(token));
         this.auth.validateToken(oauth.AccessToken).subscribe({
-          next: _ => {
+          next: tokenIsValid => {
+            if (!tokenIsValid) {
+              this.onLoginFailed();
+              return;
+            }
+
             this.auth.setToken(oauth);
 
             const redirect = window.localStorage.getItem('login-redirect');

--- a/src/src/app/view/twitch/twitch-bot-config/twitch-bot-config.ts
+++ b/src/src/app/view/twitch/twitch-bot-config/twitch-bot-config.ts
@@ -83,7 +83,11 @@ export class TwitchBotConfig implements OnInit, OnDestroy {
 
         const oauth = JSON.parse(atob(token));
         this.auth.validateToken(oauth.AccessToken).subscribe({
-          next: _ => {
+          next: tokenIsValid => {
+            if (!tokenIsValid) {
+              this.onLoginFailed();
+            }
+
             this.auth.setToken(oauth);
 
             // Check if the bot account is modded. If it isn't, we can offer to mod it.

--- a/src/src/environments/environment.development.ts
+++ b/src/src/environments/environment.development.ts
@@ -1,6 +1,7 @@
 import {allEnvironments} from "./environments-all";
 
 export const environment = {
+  domain: 'localhost',
   siteUrl: 'http://localhost:4200',
   apiUrl: 'http://localhost:5036/api/v1',
   nullApiUrl: 'http://localhost:5219/null/v1',

--- a/src/src/environments/environment.ts
+++ b/src/src/environments/environment.ts
@@ -1,6 +1,7 @@
 import {allEnvironments} from "./environments-all"
 
 export const environment = {
+  domain: 'nullinside.com',
   siteUrl: 'https://nullinside.com',
   apiUrl: 'https://nullinside.com/api/v1',
   nullApiUrl: 'https://nullinside.com/null/v1',


### PR DESCRIPTION
Originally, I made the API endpoint for validating a token pass back a 401 to indicate that it had failed. That's not really user friendly for people and not really in-line with the way I've seen rest apis do this in this past.

It now utilizes the true/false response.

I also removed calls to roles without being authenticated. Again, this clogs up the log and causes people to panic. It's better this way.

closes #175
closes #170